### PR TITLE
Set main in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fontfaceobserver",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Detect if web fonts are available",
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test": "test"
   },
   "repository": "https://github.com/bramstein/fontfaceobserver.git",
+  "main": "fontfaceobserver.js",
   "keywords": [
     "fontloader",
     "fonts",


### PR DESCRIPTION
The package.json file is missing a [main](https://docs.npmjs.com/files/package.json#main) which is really annoying to someone who wants to use this as a module. Can we be opinionated enough to just assume people are going to choose a promise implementation and thus we can just set main to `fontfaceobserver.js` and get on with it?

That lets me as a consumer do:

```javascript
var FontFaceObserver = require('fontfaceobserver');
```