### PR TITLE
make constructor descriptor object optional

### DIFF
--- a/src/observer.js
+++ b/src/observer.js
@@ -13,6 +13,7 @@ goog.scope(function () {
    * @param {fontface.Descriptors} descriptors
    */
   fontface.Observer = function (family, descriptors) {
+    descriptors = descriptors || {};
     /**
      * @type {string}
      */


### PR DESCRIPTION
Hi there,
Thanks for awesome tool! 

I was just setting it up for my website, and it just seems a bit unnecessary to me to require users to pass in a `descriptor` object, even if they are fine with the defaults. I think it would be better to fall back to an empty object, which is what your code seems to expect.

This would allow people to call `fontfaceobserver` with just one argument:
`var observer = new FontFaceObserver('My Family');`

Let me know what you think. I didn't update any of your generated files because I couldn't fine and build setup in the repo.

Once again, thanks for the tool!

Cheers