### PR TITLE
allow removeContainer to remove container from non-body parent

### DIFF
--- a/src/observer.js
+++ b/src/observer.js
@@ -128,7 +128,7 @@ goog.scope(function () {
        */
       function removeContainer() {
         if (container.parentNode !== null) {
-          dom.remove(document.body, container);
+          dom.remove(container.parentNode, container);
         }
       }
 


### PR DESCRIPTION
if another library such as an off-canvas-menu moves children of
body into another element in onLoad, the container will not be
a child of body, and attempting to remove it from body causes an
error. Remove container from its parent, regardless of what that
parent is at removal time.