### PR TITLE
On small devices, Ruler creates white bar on right side of screen

### DIFF
--- a/src/ruler.js
+++ b/src/ruler.js
@@ -55,6 +55,7 @@ goog.scope(function () {
     dom.style(this.element, 'min-width:20px;' +
                             'min-height:20px;' +
                             'display:inline-block;' +
+                            'overflow:hidden;' +
                             'position:absolute;' +
                             'width:auto;' +
                             'margin:0;' +


### PR DESCRIPTION
On small devices (e.g. iPhone), the check Font Face Observer makes creates a very large div to measure against. This, especially with the second div that it is doing the check, creates the white-bar effect on the right side of the page. 

This little PR just changes that to allow for an `overflow: hidden` to be added to that div. Not sure if this will break it, I am trying to test locally, but am having some difficulty. It does seem to fix the white bar issue. 

I can also send over a link to test this issue btw— just DM for it. 