### PR TITLE
Change how npm package is referenced

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you're using npm you can install Font Face Observer as a dependency:
 $ npm install fontfaceobserver
 ```
 
-You can then include `node_modules/fontfaceobserver/fontfaceobserver.js`. If you're not using npm, grab `fontfaceobserver.js` and include it in your project.
+You can then include `fontfaceobserver/fontfaceobserver.js`. If you're not using npm, grab `fontfaceobserver.js` and include it in your project.
 
 ## Browser support
 


### PR DESCRIPTION
The referenced npm package is automatically resolved by the npm and therefore it's more future proof.

For example, if you install using npm 3 and flat hierarchy, you might encounter a problem if the package is moved to an upper level. This would happen if you have a project that is using an npm module that has a FontFaceObserver dependency.