### PR TITLE
Clear the #checkForInterval() timeout when resolving promise.

### DIFF
--- a/src/observer.js
+++ b/src/observer.js
@@ -44,6 +44,11 @@ goog.scope(function () {
      * @type {string}
      */
     this['featureSettings'] = descriptors.featureSettings || 'normal';
+
+    /**
+     * @type {integer}
+     */
+    this['timeoutId'] = null;
   };
 
   var Observer = fontface.Observer;
@@ -161,10 +166,12 @@ goog.scope(function () {
                     (widthA === fallbackWidthC && widthB === fallbackWidthC && widthC === fallbackWidthC))) {
                 // The width we got doesn't match any of the known last resort fonts, so let's assume fonts are loaded.
                 removeContainer();
+                clearTimeout(that.timeoutId);
                 resolve(that);
               }
             } else {
               removeContainer();
+              clearTimeout(that.timeoutId);
               resolve(that);
             }
           }
@@ -202,7 +209,7 @@ goog.scope(function () {
               widthC = rulerC.getWidth();
               check();
             }
-            setTimeout(checkForTimeout, 50);
+            that.timeoutId = setTimeout(checkForTimeout, 50);
           }
         }
 


### PR DESCRIPTION
Because the timeout was never canceled, resolving the promise didn't stop FFO from looping through its check functions, which always wound up timing out and sending an objection. The built-in polyfill swallowed the rejection, as the spec suggests it should, but Bluebird was logging the following message each time FontFaceObserver ran:

```
Warning: a promise was rejected with a non-error: [object Object]
    at a (http://knit-wit.submish.dev/assets/js/5.js:358:395)
From previous event:
    at z.a (http://knit-wit.submish.dev/assets/js/5.js:357:440)
    at http://knit-wit.submish.dev/assets/js/boot.js:27463:9
    at http://knit-wit.submish.dev/assets/js/boot.js:109:24
    at webpackJsonpCallback (http://knit-wit.submish.dev/assets/js/boot.js:19:31)
    at http://knit-wit.submish.dev/assets/js/5.js:1:1
```

This PR calls `clearTimeout` when the promise is resolved to terminate the checking loop and give my dev console some peace.

Thanks so much for this utility, it's really a life saver!