### PR TITLE
Rename check to load

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,33 +11,33 @@ var observer = new FontFaceObserver('My Family', {
   weight: 400
 });
 
-observer.check().then(function () {
+observer.load().then(function () {
   console.log('Font is available');
 }, function () {
   console.log('Font is not available');
 });
 ```
 
-The `FontFaceObserver` constructor takes two arguments: the font family name (required) and an object describing the variation (optional). The object can contain `weight`, `style`, and `stretch` properties. If a property is not present it will default to `normal`. To start observing font loads, call the `check` method. It'll immediately return a new Promise that resolves when the font is available and rejected when the font is not available.
+The `FontFaceObserver` constructor takes two arguments: the font family name (required) and an object describing the variation (optional). The object can contain `weight`, `style`, and `stretch` properties. If a property is not present it will default to `normal`. To start observing font loads, call the `load` method. It'll immediately return a new Promise that resolves when the font is available and rejected when the font is not available.
 
-If your font doesn't contain latin characters you can pass a custom test string to the `check` method.
+If your font doesn't contain latin characters you can pass a custom test string to the `load` method.
 
 ```js
 var observer = new FontFaceObserver('My Family');
 
-observer.check('中国').then(function () {
+observer.load('中国').then(function () {
   console.log('Font is available');
 }, function () {
   console.log('Font is not available');
 });
 ```
 
-The default timeout for giving up on font loading is 3 seconds. You can increase or decrease this by passing a number of milliseconds as the second parameter to the `check` method.
+The default timeout for giving up on font loading is 3 seconds. You can increase or decrease this by passing a number of milliseconds as the second parameter to the `load` method.
 
 ```js
 var observer = new FontFaceObserver('My Family');
 
-observer.check(null, 5000).then(function () {
+observer.load(null, 5000).then(function () {
   console.log('Font is available');
 }, function () {
   console.log('Font is not available after waiting 5 seconds');
@@ -50,22 +50,22 @@ Multiple fonts can be loaded by creating a FontFaceObserver instance for each.
 var observer = new FontFaceObserver('Family A');
 var observer2 = new FontFaceObserver('Family B');
 
-observer.check().then(function () {
+observer.load().then(function () {
   console.log('Family A is available');
 });
 
-observer2.check().then(function () {
+observer2.load().then(function () {
   console.log('Family B is available');
 });
 ```
 
-You may also check both are loaded, rather than checking each individually.
+You may also load both at the same time, rather than loading each individually.
 
 ```js
 var observer = new FontFaceObserver('Family A');
 var observer2 = new FontFaceObserver('Family B');
 
-Promise.all([observer.check(), observer2.check()]).then(function () {
+Promise.all([observer.load(), observer2.load()]).then(function () {
   console.log('Family A & B have loaded');
 });
 ```
@@ -75,7 +75,7 @@ The following example emulates FOUT with Font Face Observer for "MyWebFont".
 ```js
 var observer = new FontFaceObserver('MyWebFont');
 
-observer.check().then(function () {
+observer.load().then(function () {
   document.documentElement.className += " fonts-loaded";
 });
 ```
@@ -103,7 +103,7 @@ var FontFaceObserver = require('fontfaceobserver');
 
 var observer = new FontFaceObserver('My Family');
 
-observer.check().then(function () {
+observer.load().then(function () {
   console.log('My Family has loaded');
 });
 ```

--- a/exports.js
+++ b/exports.js
@@ -6,7 +6,7 @@ goog.require('fontface.Observer');
 var DEBUG = true;
 
 window['FontFaceObserver'] = fontface.Observer;
-window['FontFaceObserver']['prototype']['check'] = fontface.Observer.prototype.check;
+window['FontFaceObserver']['prototype']['check'] = window['FontFaceObserver']['prototype']['load'] = fontface.Observer.prototype.load;
 
 if (typeof module !== 'undefined') {
   module.exports = window['FontFaceObserver'];

--- a/externs.js
+++ b/externs.js
@@ -12,4 +12,4 @@ var FontFaceObserver = function (family, descriptors) {};
  *
  * @return {Promise.<FontFaceObserver>}
  */
-FontFaceObserver.prototype.check = function (opt_text, opt_timeout) {};
+FontFaceObserver.prototype.load = function (opt_text, opt_timeout) {};

--- a/src/observer.js
+++ b/src/observer.js
@@ -126,7 +126,7 @@ goog.scope(function () {
    * @param {number=} timeout Optional timeout for giving up on font load detection and rejecting the promise (defaults to 3 seconds).
    * @return {Promise.<fontface.Observer>}
    */
-  Observer.prototype.check = function (text, timeout) {
+  Observer.prototype.load = function (text, timeout) {
     var that = this;
     var testString = text || 'BESbswy';
     var timeoutValue = timeout || Observer.DEFAULT_TIMEOUT;

--- a/test/observer-test.js
+++ b/test/observer-test.js
@@ -6,7 +6,7 @@ describe('Observer', function () {
     it('creates a new instance with the correct signature', function () {
       var observer = new Observer('my family', {});
       expect(observer, 'not to be', null);
-      expect(observer.check, 'to be a function');
+      expect(observer.load, 'to be a function');
     });
 
     it('parses descriptors', function () {
@@ -53,7 +53,7 @@ describe('Observer', function () {
     });
   });
 
-  describe('#check', function () {
+  describe('#load', function () {
     this.timeout(5000);
 
     it('finds a font and resolve the promise', function (done) {
@@ -66,7 +66,7 @@ describe('Observer', function () {
       var beforeWidth = ruler.getWidth();
 
       ruler.setFont('100px observer-test1, monospace');
-      observer.check(null, 5000).then(function () {
+      observer.load(null, 5000).then(function () {
         var activeWidth = ruler.getWidth();
 
         expect(activeWidth, 'not to equal', beforeWidth);
@@ -94,7 +94,7 @@ describe('Observer', function () {
       var beforeWidth = ruler.getWidth();
 
       ruler.setFont('100px observer-test9, monospace');
-      observer.check(null, 10000).then(function () {
+      observer.load(null, 10000).then(function () {
         var activeWidth = ruler.getWidth();
 
         expect(activeWidth, 'not to equal', beforeWidth);
@@ -132,7 +132,7 @@ describe('Observer', function () {
       var beforeWidth = ruler.getWidth();
 
       ruler.setFont('100px observer-test1, monospace');
-      observer.check(null, 5000).then(function () {
+      observer.load(null, 5000).then(function () {
         var activeWidth = ruler.getWidth();
 
         expect(activeWidth, 'not to equal', beforeWidth);
@@ -162,7 +162,7 @@ describe('Observer', function () {
       var beforeWidth = ruler.getWidth();
 
       ruler.setFont('100px "Trebuchet W01 Regular", monospace');
-      observer.check(null, 5000).then(function () {
+      observer.load(null, 5000).then(function () {
         var activeWidth = ruler.getWidth();
 
         expect(activeWidth, 'not to equal', beforeWidth);
@@ -183,7 +183,7 @@ describe('Observer', function () {
     it('fails to find a font and reject the promise', function (done) {
       var observer = new Observer('observer-test2', {});
 
-      observer.check(null, 50).then(function () {
+      observer.load(null, 50).then(function () {
         done(new Error('Should not resolve'));
       }, function () {
         done();
@@ -193,8 +193,8 @@ describe('Observer', function () {
     it('finds the font even if it is already loaded', function (done) {
       var observer = new Observer('observer-test3', {});
 
-      observer.check(null, 5000).then(function () {
-        observer.check(null, 5000).then(function () {
+      observer.load(null, 5000).then(function () {
+        observer.load(null, 5000).then(function () {
           done();
         }, function () {
           done(new Error('Second call failed'));
@@ -215,7 +215,7 @@ describe('Observer', function () {
 
       ruler.setFont('100px observer-test4,monospace');
 
-      observer.check('\u0021', 5000).then(function () {
+      observer.load('\u0021', 5000).then(function () {
         var activeWidth = ruler.getWidth();
 
         expect(activeWidth, 'not to equal', beforeWidth);
@@ -245,7 +245,7 @@ describe('Observer', function () {
 
       ruler.setFont('100px observer-test5,monospace');
 
-      observer.check('\u4e2d\u56fd', 5000).then(function () {
+      observer.load('\u4e2d\u56fd', 5000).then(function () {
         var activeWidth = ruler.getWidth();
 
         expect(activeWidth, 'not to equal', beforeWidth);
@@ -276,7 +276,7 @@ describe('Observer', function () {
 
       ruler.setFont('100px observer-test6,monospace');
 
-      observer.check('\udbff\udfff', 5000).then(function () {
+      observer.load('\udbff\udfff', 5000).then(function () {
         var activeWidth = ruler.getWidth();
 
         expect(activeWidth, 'not to equal', beforeWidth);
@@ -299,7 +299,7 @@ describe('Observer', function () {
     it('fails to find the font if it is available but does not contain the test string', function (done) {
       var observer = new Observer('observer-test7', {});
 
-      observer.check(null, 50).then(function () {
+      observer.load(null, 50).then(function () {
         done(new Error('Should not be called'));
       }, function () {
         done();
@@ -309,7 +309,7 @@ describe('Observer', function () {
     xit('finds a locally installed font', function (done) {
       var observer = new Observer('sans-serif', {});
 
-      observer.check(null, 50).then(function () {
+      observer.load(null, 50).then(function () {
         done();
       }, function () {
         done(new Error('Did not detect local font'));
@@ -319,7 +319,7 @@ describe('Observer', function () {
     xit('finds a locally installed font with the same metrics as the a fallback font (on OS X)', function (done) {
       var observer = new Observer('serif', {});
 
-      observer.check(null, 50).then(function () {
+      observer.load(null, 50).then(function () {
         done();
       }, function () {
         done(new Error('Did not detect local font'));


### PR DESCRIPTION
This renames `check` to `load`, which is more in line with what it actually does.