### PR TITLE
Clearing a reject timeout if the promise has resolved

### DIFF
--- a/src/observer.js
+++ b/src/observer.js
@@ -142,6 +142,7 @@ goog.scope(function () {
   Observer.prototype.load = function (text, timeout) {
     var that = this;
     var testString = text || 'BESbswy';
+    var timeoutId = 0;
     var timeoutValue = timeout || Observer.DEFAULT_TIMEOUT;
     var start = that.getTime();
 
@@ -169,10 +170,11 @@ goog.scope(function () {
         });
 
         var timer = new Promise(function (resolve, reject) {
-          setTimeout(reject, timeoutValue);
+          timeoutId = setTimeout(reject, timeoutValue);
         });
 
         Promise.race([timer, loader]).then(function () {
+          clearTimeout( timeoutId );
           resolve(that);
         }, function () {
           reject(that);
@@ -192,8 +194,6 @@ goog.scope(function () {
           var fallbackWidthC = -1;
 
           var container = dom.createElement('div');
-
-          var timeoutId = 0;
 
           /**
            * @private

--- a/src/observer.js
+++ b/src/observer.js
@@ -174,7 +174,7 @@ goog.scope(function () {
         });
 
         Promise.race([timer, loader]).then(function () {
-          clearTimeout( timeoutId );
+          clearTimeout(timeoutId);
           resolve(that);
         }, function () {
           reject(that);


### PR DESCRIPTION
When using bluebird as our promise polyfill, despite the fontfaceobserver resolving the promise successfully, I was still seeing a rejected promise coming from the lib. Tracked it down to a setTimeout that was still running despite the resolve being called.

Very similar to the issue previously fixed within https://github.com/bramstein/fontfaceobserver/pull/43