### PR TITLE
Modified the check for the Safari 10 bug to look at AppleWebKit versions

### DIFF
--- a/src/observer.js
+++ b/src/observer.js
@@ -105,28 +105,22 @@ goog.scope(function () {
    *  - https://bugs.webkit.org/show_bug.cgi?id=165037
    *  - https://bugs.webkit.org/show_bug.cgi?id=164902
    *
-   * Safari 10.0 was around AppleWebKit version 602, so any
-   * versions do not have the bug.
-   * These bugs was fixed in Safari Technology Preview 19, which
-   * corresponds to AppleWebKit version 603.1.14, so any
-   * version later than this does not have the bug either.
-   * So we simply check if it's an Apple-browser with a
-   * AppleWebKit version between 602 and 603.1.14.
+   * If the browser is made by Apple, and has native font
+   * loading support, it is potentially affected. But the API
+   * was fixed around AppleWebKit version 603, so any newer
+   * versions that that does not contain the bug.
    *
    * @return {boolean}
    */
   Observer.hasSafari10Bug = function () {
     if (Observer.HAS_SAFARI_10_BUG === null) {
-      var match = /AppleWebKit\/([0-9]+)(?:\.([0-9]+))(?:\.([0-9]+))/.exec(Observer.getUserAgent());
+      if (Observer.supportsNativeFontLoading() && /Apple/.test(Observer.getNavigatorVendor())) {
+        var match = /AppleWebKit\/([0-9]+)(?:\.([0-9]+))(?:\.([0-9]+))/.exec(Observer.getUserAgent());
 
-      Observer.HAS_SAFARI_10_BUG = !!match &&
-                                    (/Apple/.test(Observer.getNavigatorVendor()) &&
-                                     (parseInt(match[1], 10) >= 602 &&
-                                      (parseInt(match[1], 10) < 603 ||
-                                       (parseInt(match[1], 10) === 603 &&
-                                        (parseInt(match[2], 10) < 1 ||
-                                         (parseInt(match[2], 10) === 1 &&
-                                          parseInt(match[3], 10) < 14))))));
+        Observer.HAS_SAFARI_10_BUG = !!match && parseInt(match[1], 10) < 603;
+      } else {
+        Observer.HAS_SAFARI_10_BUG = false;
+      }
     }
     return Observer.HAS_SAFARI_10_BUG;
   };

--- a/src/observer.js
+++ b/src/observer.js
@@ -96,23 +96,37 @@ goog.scope(function () {
   };
 
   /**
-   * Returns true if this browser is Safari 10. The native font
-   * load API in Safari 10 has two bugs that cause the
-   * document.fonts.load and FontFace.prototype.load methods to
-   * return promises that don't reliably get settled.
+   * Returns true if the browser has the Safari 10 bugs. The
+   * native font load API in Safari 10 has two bugs that cause
+   * the document.fonts.load and FontFace.prototype.load methods
+   * to return promises that don't reliably get settled.
    *
    * The bugs are described in more detail here:
    *  - https://bugs.webkit.org/show_bug.cgi?id=165037
    *  - https://bugs.webkit.org/show_bug.cgi?id=164902
    *
-   * These patches have landed in Safari 10.1, so we'll re-enable
-   * the native font loading API from that version onwards.
+   * Safari 10.0 was around AppleWebKit version 602, so any
+   * versions do not have the bug.
+   * These bugs was fixed in Safari Technology Preview 19, which
+   * corresponds to AppleWebKit version 603.1.14, so any
+   * version later than this does not have the bug either.
+   * So we simply check if it's an Apple-browser with a
+   * AppleWebKit version between 602 and 603.1.14.
    *
    * @return {boolean}
    */
   Observer.hasSafari10Bug = function () {
     if (Observer.HAS_SAFARI_10_BUG === null) {
-      Observer.HAS_SAFARI_10_BUG = /OS X.*Version\/10\.0.*Safari/.test(Observer.getUserAgent()) && /Apple/.test(Observer.getNavigatorVendor());
+      var match = /AppleWebKit\/([0-9]+)(?:\.([0-9]+))(?:\.([0-9]+))/.exec(Observer.getUserAgent());
+
+      Observer.HAS_SAFARI_10_BUG = !!match &&
+                                    (/Apple/.test(Observer.getNavigatorVendor()) &&
+                                     (parseInt(match[1], 10) >= 602 &&
+                                      (parseInt(match[1], 10) < 603 ||
+                                       (parseInt(match[1], 10) === 603 &&
+                                        (parseInt(match[2], 10) < 1 ||
+                                         (parseInt(match[2], 10) === 1 &&
+                                          parseInt(match[3], 10) < 14))))));
     }
     return Observer.HAS_SAFARI_10_BUG;
   };

--- a/test/observer-test.js
+++ b/test/observer-test.js
@@ -378,8 +378,15 @@ describe('Observer', function () {
       expect(Observer.hasSafari10Bug(), 'to be false');
     });
 
-    it('returns true if the Safari 10 font loading bug is present', function () {
+    it('returns true if the browser is an affected version of Safari 10', function () {
       getUserAgent.returns('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/602.2.14 (KHTML, like Gecko) Version/10.0.1 Safari/602.2.14');
+      getNavigatorVendor.returns('Apple');
+
+      expect(Observer.hasSafari10Bug(), 'to be true');
+    });
+
+    it('returns true if the browser is an WebView with an affected version of Safari 10', function () {
+      getUserAgent.returns('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/602.2.14 (KHTML, like Gecko) FxiOS/6.1 Safari/602.2.14');
       getNavigatorVendor.returns('Apple');
 
       expect(Observer.hasSafari10Bug(), 'to be true');

--- a/test/observer-test.js
+++ b/test/observer-test.js
@@ -358,22 +358,26 @@ describe('Observer', function () {
   describe('hasSafari10Bug', function () {
     var getUserAgent = null;
     var getNavigatorVendor = null;
+    var supportsNativeFontLoading = null;
 
     beforeEach(function () {
       Observer.HAS_SAFARI_10_BUG = null;
 
       getUserAgent = sinon.stub(Observer, 'getUserAgent');
       getNavigatorVendor = sinon.stub(Observer, 'getNavigatorVendor');
+      supportsNativeFontLoading = sinon.stub(Observer, 'supportsNativeFontLoading');
     });
 
     afterEach(function () {
       getUserAgent.restore();
       getNavigatorVendor.restore();
+      supportsNativeFontLoading.restore();
     });
 
     it('returns false when the user agent is not WebKit', function () {
       getUserAgent.returns('Mozilla/5.0 (Android; Mobile; rv:13.0) Gecko/15.0 Firefox/14.0');
       getNavigatorVendor.returns('Google');
+      supportsNativeFontLoading.returns(true);
 
       expect(Observer.hasSafari10Bug(), 'to be false');
     });
@@ -381,6 +385,7 @@ describe('Observer', function () {
     it('returns true if the browser is an affected version of Safari 10', function () {
       getUserAgent.returns('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/602.2.14 (KHTML, like Gecko) Version/10.0.1 Safari/602.2.14');
       getNavigatorVendor.returns('Apple');
+      supportsNativeFontLoading.returns(true);
 
       expect(Observer.hasSafari10Bug(), 'to be true');
     });
@@ -388,6 +393,7 @@ describe('Observer', function () {
     it('returns true if the browser is an WebView with an affected version of Safari 10', function () {
       getUserAgent.returns('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/602.2.14 (KHTML, like Gecko) FxiOS/6.1 Safari/602.2.14');
       getNavigatorVendor.returns('Apple');
+      supportsNativeFontLoading.returns(true);
 
       expect(Observer.hasSafari10Bug(), 'to be true');
     });
@@ -395,6 +401,7 @@ describe('Observer', function () {
     it('returns false in older versions of Safari', function () {
       getUserAgent.returns('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.75.14 (KHTML, like Gecko) Version/9.3.2 Safari/537.75.14');
       getNavigatorVendor.returns('Apple');
+      supportsNativeFontLoading.returns(false);
 
       expect(Observer.hasSafari10Bug(), 'to be false');
     });
@@ -402,6 +409,7 @@ describe('Observer', function () {
     it('returns false in newer versions of Safari', function () {
       getUserAgent.returns('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/603.1.20 (KHTML, like Gecko) Version/10.1 Safari/603.1.20');
       getNavigatorVendor.returns('Apple');
+      supportsNativeFontLoading.returns(true);
 
       expect(Observer.hasSafari10Bug(), 'to be false');
     });


### PR DESCRIPTION
This PR is an attempt at fixing #93.

I have modified the `hasSafari10Bug` method such that it looks at AppleWebKit version (between 602 and 603.1.14) instead of Safari versions. The reasons for this, as outlined in #93, is that VKWebView and it's likes on iOS does not contain the Safari version-number, but only the AppleWebKit version number.

I updated the test-cases to also add a UA for Firefox for iOS (*FxiOS*) - but I need to double-check that it is indeed the exact UA of FxiOS. I'll do that next time I get my hands on our test iOS device at work.

**Possible improvements**
- Figure out the exact AppleWebKit version for Safari 10 GM instead of just >602.0.0 (I think 602.1.50, but it's annoyingly hard to find exact information on.
- Refactor AppleWebKit version comparisons into a helper-function. Now there are a total of three checks (>=536.11 for the fallback, and >602 and <=603.1.14), and they are very bad-looking if-statements.

Let me know if I should try and do more work on any of those two issues (or something third).

I also wasn't sure if the PR should contain the compiled versions of the lib (the result of `grunt dist`), so if it should let me know, and then I'll add them in.

Kind regards
Morten