### PR TITLE
Check that module is an object, rather than that it's defined

### DIFF
--- a/exports.js
+++ b/exports.js
@@ -1,6 +1,6 @@
 goog.require('fontface.Observer');
 
-if (typeof module !== 'undefined') {
+if (typeof module === 'object') {
   module.exports = fontface.Observer;
 } else {
   window['FontFaceObserver'] = fontface.Observer;


### PR DESCRIPTION
The exports check for commonjs is matching if there are any globally defined module variables. `typeof module !== 'undefined'`

Unfortunately, qunit declares a global `module` function that's used to write qunit tests.

Looking around some other third party libraries we used they check `typeof module === 'object'` which doesn't trigger in a qunit environment.

This PR swaps the exports check to checking it's an `'object'` rather than not `'undefined'`.

An alternative would be to do a umd-style export check: https://github.com/umdjs/umd/blob/master/templates/commonjsStrict.js#L23

I'd be happy to change this PR if that would be preferred.