### PR TITLE
Replace document.fonts.load with check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 node_modules
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 node_modules
 /.idea
+/package-lock.json

--- a/src/observer.js
+++ b/src/observer.js
@@ -88,9 +88,9 @@ goog.scope(function () {
       var match = /AppleWebKit\/([0-9]+)(?:\.([0-9]+))/.exec(Observer.getUserAgent());
 
       Observer.HAS_WEBKIT_FALLBACK_BUG = !!match &&
-                                          (parseInt(match[1], 10) < 536 ||
-                                           (parseInt(match[1], 10) === 536 &&
-                                            parseInt(match[2], 10) <= 11));
+          (parseInt(match[1], 10) < 536 ||
+          (parseInt(match[1], 10) === 536 &&
+          parseInt(match[2], 10) <= 11));
     }
     return Observer.HAS_WEBKIT_FALLBACK_BUG;
   };
@@ -197,15 +197,11 @@ goog.scope(function () {
             if (now - start >= timeoutValue) {
               reject();
             } else {
-              document.fonts.load(that.getStyle('"' + that['family'] + '"'), testString).then(function (fonts) {
-                if (fonts.length >= 1) {
-                  resolve();
-                } else {
-                  setTimeout(check, 25);
-                }
-              }, function () {
-                reject();
-              });
+              if(document.fonts.check(that.getStyle('"' + that['family'] + '"'))){
+                resolve();
+              } else {
+                setTimeout(check, 25);
+              }
             }
           };
           check();
@@ -271,8 +267,8 @@ goog.scope(function () {
                   // values are set to one of the last resort fonts.
 
                   if (((widthA == fallbackWidthA && widthB == fallbackWidthA && widthC == fallbackWidthA) ||
-                        (widthA == fallbackWidthB && widthB == fallbackWidthB && widthC == fallbackWidthB) ||
-                        (widthA == fallbackWidthC && widthB == fallbackWidthC && widthC == fallbackWidthC))) {
+                      (widthA == fallbackWidthB && widthB == fallbackWidthB && widthC == fallbackWidthB) ||
+                      (widthA == fallbackWidthC && widthB == fallbackWidthC && widthC == fallbackWidthC))) {
                     // The width we got matches some of the known last resort fonts, so let's assume we're dealing with the last resort font.
                     return;
                   }


### PR DESCRIPTION
We use this lib in several projects and were getting a lot of timeouts for fonts that actually did load. After fixing several issues related to the handling of the returned promise I still found that in browsers that natively support the font loading API there were issues. After evaluating the code the most likely culprit appeared to be document.fonts.load. Replacing with check resolved our issues. However I wan only able to run our tests against the revised lib. When I ran `grunt test` I got some errors about not being able to execute phatomJS. So you'll want to test this change.