### PR TITLE
Reject promises with Error objects

### DIFF
--- a/src/observer.js
+++ b/src/observer.js
@@ -195,7 +195,7 @@ goog.scope(function () {
             var now = that.getTime();
 
             if (now - start >= timeoutValue) {
-              reject();
+              reject(new Error('' + timeoutValue + 'ms timeout exceeded'));
             } else {
               document.fonts.load(that.getStyle('"' + that['family'] + '"'), testString).then(function (fonts) {
                 if (fonts.length >= 1) {
@@ -203,24 +203,23 @@ goog.scope(function () {
                 } else {
                   setTimeout(check, 25);
                 }
-              }, function () {
-                reject();
-              });
+              }, reject);
             }
           };
           check();
         });
 
         var timer = new Promise(function (resolve, reject) {
-          timeoutId = setTimeout(reject, timeoutValue);
+          timeoutId = setTimeout(
+            function() { reject(new Error('' + timeoutValue + 'ms timeout exceeded')); },
+            timeoutValue
+          );
         });
 
         Promise.race([timer, loader]).then(function () {
           clearTimeout(timeoutId);
           resolve(that);
-        }, function () {
-          reject(that);
-        });
+        }, reject);
       } else {
         dom.waitForBody(function () {
           var rulerA = new Ruler(testString);
@@ -306,7 +305,7 @@ goog.scope(function () {
 
             if (now - start >= timeoutValue) {
               removeContainer();
-              reject(that);
+              reject(new Error('' + timeoutValue + 'ms timeout exceeded'));
             } else {
               var hidden = document['hidden'];
               if (hidden === true || hidden === undefined) {

--- a/test/observer-test.js
+++ b/test/observer-test.js
@@ -213,8 +213,14 @@ describe('Observer', function () {
 
       observer.load(null, 50).then(function () {
         done(new Error('Should not resolve'));
-      }, function () {
-        done();
+      }, function (err) {
+        try {
+          expect(err.message, 'to equal', '50ms timeout exceeded');
+          expect(err.constructor.name, 'to equal', 'Error');
+          done();
+        } catch(testFailure) {
+          done(testFailure);
+        }
       });
     });
 


### PR DESCRIPTION
Ensures all `Promise`s are rejected with an `Error` object by either

- Constructing one manually (in the case of timeouts)
- Forwarding an existing error (`document.fonts.load`, `Promise.race`)

This makes it a lot easier to debug load errors as `Error`s provide stack traces.